### PR TITLE
48 - Auxiliary services (MongoDB + Redis)

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -2,10 +2,16 @@
 'use strict';
 const express = require('express');
 const payload = require('./payload');
+const bootstrap = require('./src/bootstrap');
 
 const host = '0.0.0.0';
 const env = process.env.Environment || '';
 const port = (env == 'prod' ||  env == 'uat' || env == 'docker') ? 80 : 8081;
+const mongoUrl = process.env.MongoUrl || 'mongodb://localhost/nookr';
+
+bootstrap.run({ mongoUrl })
+  .then((r) => console.log(`instance: ${r._id}`))
+  .catch(console.error);
 
 const app = express();
 

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.16.3"
+    "express": "^4.16.3",
+    "mongoose": "^5.0.11"
   },
   "devDependencies": {
     "nodemon": "^1.17.2"

--- a/api/src/bootstrap.js
+++ b/api/src/bootstrap.js
@@ -1,0 +1,17 @@
+// This module just adds a line to the database
+// with a start time. It serves as a simple code
+// example and can be used for basic troubleshooting.
+var mongoose = require('mongoose');
+
+const instanceSchema = mongoose.Schema({
+  startTime: Date
+});
+const Instance = mongoose.model('Instance', instanceSchema);
+
+module.exports = {
+  run: (props) => {
+    mongoose.connect(props.mongoUrl);
+    const instance = new Instance({ startTime: new Date() });
+    return instance.save();
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  mongo:
+    image: mongo
+    ports:
+    - "27017:27017"
+    volumes:
+    - mongo-data:/data/db
+    restart: always
+  redis:
+    image: redis:alpine
+    ports:
+    - "6379:6379"
+    volumes:
+    - redis-data:/data
+    restart: always
+volumes:
+  redis-data:
+  mongo-data:

--- a/infra/auxiliary/.gitignore
+++ b/infra/auxiliary/.gitignore
@@ -1,0 +1,1 @@
+service.json

--- a/infra/auxiliary/deploy.sh
+++ b/infra/auxiliary/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+revision=$(aws ecs register-task-definition --cli-input-json file://task-definition.json | jq  '.taskDefinition.revision')
+sed "s/TASK_DEFINITION/$revision/g" service-template.json > service.json
+aws ecs create-service --cli-input-json file://service.json

--- a/infra/auxiliary/service-template.json
+++ b/infra/auxiliary/service-template.json
@@ -1,0 +1,10 @@
+{
+    "cluster": "nookr",
+    "serviceName": "nookr-aux",
+    "taskDefinition": "nookr-aux:TASK_DEFINITION",
+    "desiredCount": 1,
+    "deploymentConfiguration": {
+        "maximumPercent": 200,
+        "minimumHealthyPercent": 0
+    }
+}

--- a/infra/cloudformation/cloudwatch-logs.yml
+++ b/infra/cloudformation/cloudwatch-logs.yml
@@ -10,3 +10,18 @@ Resources:
     Properties:
       LogGroupName: nookr-ui
       RetentionInDays: 14
+  LogGroupProxy:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: nookr-proxy
+      RetentionInDays: 14
+  LogGroupMongo:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: nookr-mongo
+      RetentionInDays: 14
+  LogGroupRedis:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: nookr-redis
+      RetentionInDays: 14

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,43 @@
 ## nook.io
 
-Where books live
+
+**Local Development - Auxiliary services**
+
+* [MongoDB](https://www.mongodb.com/) is a popular NoSQL database which is fairly straight forward to get started with
+* [Redis](https://redis.io/) is an in-memory data store
+
+
+
+**When to use what (in the context of this app only)?**
+
+* For data that needs to persist, use MongoDB. Examples include cached books and user profile data
+* In situations where it doesn't matter if you lose the data, use redis. Examples include cached data and user session information.
+
+
+
+**Running the services locally**
+
+For local running of services, a `docker-compose.yml` file has been added to the root of the project. To bring up the services, ensure that you have a terminal session in the root of the project and use the command
+
+```
+$ docker-compose up -d
+```
+
+This will bring the containers online. 
+
+
+
+**Accessing the services locally**
+
+There are several tools which are appropriaate for accessing redis and node, this is beyond the scope of this document however here are  some examples for OSX
+
+* Redis: [redis-cli](https://redis.io/topics/rediscli)
+* Redis: [redis-desktop-manager](https://redisdesktop.com/)
+* Redis: [medis](https://github.com/luin/medis)
+* Mongo: [Robo 3T][https://robomongo.org/]
+
+
+
+**Accessing the services remotely**
+
+Add your ip address to the `nookr-network-security-operators` security group and use `srv.nookr.io` as the host name. Access using the same tooling that you would use locally

--- a/readme.md
+++ b/readme.md
@@ -8,10 +8,12 @@
 
 
 
+
 **When to use what (in the context of this app only)?**
 
 * For data that needs to persist, use MongoDB. Examples include cached books and user profile data
 * In situations where it doesn't matter if you lose the data, use redis. Examples include cached data and user session information.
+
 
 
 
@@ -38,6 +40,13 @@ There are several tools which are appropriaate for accessing redis and node, thi
 
 
 
+
 **Accessing the services remotely**
 
 Add your ip address to the `nookr-network-security-operators` security group and use `srv.nookr.io` as the host name. Access using the same tooling that you would use locally
+
+**MongoDB:** mongodb://srv.nookr.io/nookr
+
+**Redis:** srv.nookr.io:6379 
+
+e.g. `redis-cli -h srv.nookr.io`

--- a/task-template.json
+++ b/task-template.json
@@ -50,7 +50,7 @@
             "memoryReservation": 64,
             "environment" : [
                 { "name" : "Environment", "value" : "uat" },
-                { "name" : "MongoUrl", "value" : "mongodb://srv.nookr.io/nookr" }
+                { "name" : "MongoUrl", "value" : "mongodb://aux.nookr.io/nookr" }
             ],
             "essential": false,
             "hostname": "api",

--- a/task-template.json
+++ b/task-template.json
@@ -2,20 +2,6 @@
     "family": "nookr",
     "taskRoleArn": "arn:aws:iam::238164213705:role/nookr-iam-TaskRole-1AG5NVRV57J75",
     "networkMode": "bridge",
-    "volumes": [
-        {
-          "name": "mongo-data",
-          "host": {
-            "sourcePath": "/var/nookr/mongo-data"
-          }
-        },
-        {
-          "name": "redis-data",
-          "host": {
-            "sourcePath": "/var/nookr/redis-data"
-          }
-        }
-    ],
     "containerDefinitions": [
         {
             "name": "proxy",
@@ -59,12 +45,12 @@
         {
             "name": "api",
             "image": "238164213705.dkr.ecr.ap-southeast-2.amazonaws.com/nookr-api:GITHASH",
-            "cpu": 10,
-            "memory": 64,
+            "cpu": 20,
+            "memory": 128,
             "memoryReservation": 64,
             "environment" : [
                 { "name" : "Environment", "value" : "uat" },
-                { "name" : "MongoUrl", "value" : "mongodb://mongo/nookr" }
+                { "name" : "MongoUrl", "value" : "mongodb://srv.nookr.io/nookr" }
             ],
             "essential": false,
             "hostname": "api",
@@ -75,38 +61,6 @@
                     "awslogs-group": "nookr-api"
                 }
             }
-        },
-        {
-            "name": "mongo",
-            "image": "mongo",
-            "cpu": 20,
-            "memory": 256,
-            "memoryReservation": 256,
-            "environment" : [
-                { "name" : "Environment", "value" : "uat" }
-            ],
-            "essential": true,
-            "hostname": "mongo",
-            "portMappings": [
-                {
-                    "containerPort": 27017,
-                    "hostPort": 27017,
-                    "protocol": "tcp"
-                }
-            ],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-region": "ap-southeast-2",
-                    "awslogs-group": "nookr-mongo"
-                }
-            },
-            "mountPoints": [
-                {
-                  "sourceVolume": "mongo-data",
-                  "containerPath": "/data/db"
-                }
-            ]
         }
     ]
  }

--- a/task-template.json
+++ b/task-template.json
@@ -2,14 +2,28 @@
     "family": "nookr",
     "taskRoleArn": "arn:aws:iam::238164213705:role/nookr-iam-TaskRole-1AG5NVRV57J75",
     "networkMode": "bridge",
+    "volumes": [
+        {
+          "name": "mongo-data",
+          "host": {
+            "sourcePath": "/var/nookr/mongo-data"
+          }
+        },
+        {
+          "name": "redis-data",
+          "host": {
+            "sourcePath": "/var/nookr/redis-data"
+          }
+        }
+    ],
     "containerDefinitions": [
         {
             "name": "proxy",
             "links": ["api", "ui"],
             "image": "238164213705.dkr.ecr.ap-southeast-2.amazonaws.com/nookr-proxy:GITHASH",
             "cpu": 10,
-            "memory": 50,
-            "memoryReservation": 50,
+            "memory": 64,
+            "memoryReservation": 64,
             "portMappings": [
                 {
                     "containerPort": 80,
@@ -30,8 +44,8 @@
             "name": "ui",
             "image": "238164213705.dkr.ecr.ap-southeast-2.amazonaws.com/nookr-ui:GITHASH",
             "cpu": 10,
-            "memory": 50,
-            "memoryReservation": 50,
+            "memory": 64,
+            "memoryReservation": 64,
             "essential": false,
             "hostname": "ui",
             "logConfiguration": {
@@ -46,10 +60,11 @@
             "name": "api",
             "image": "238164213705.dkr.ecr.ap-southeast-2.amazonaws.com/nookr-api:GITHASH",
             "cpu": 10,
-            "memory": 50,
-            "memoryReservation": 50,
+            "memory": 64,
+            "memoryReservation": 64,
             "environment" : [
-                { "name" : "Environment", "value" : "uat" }
+                { "name" : "Environment", "value" : "uat" },
+                { "name" : "MongoUrl", "value" : "mongodb://mongo/nookr" }
             ],
             "essential": false,
             "hostname": "api",
@@ -60,6 +75,38 @@
                     "awslogs-group": "nookr-api"
                 }
             }
+        },
+        {
+            "name": "mongo",
+            "image": "mongo",
+            "cpu": 20,
+            "memory": 256,
+            "memoryReservation": 256,
+            "environment" : [
+                { "name" : "Environment", "value" : "uat" }
+            ],
+            "essential": true,
+            "hostname": "mongo",
+            "portMappings": [
+                {
+                    "containerPort": 27017,
+                    "hostPort": 27017,
+                    "protocol": "tcp"
+                }
+            ],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-region": "ap-southeast-2",
+                    "awslogs-group": "nookr-mongo"
+                }
+            },
+            "mountPoints": [
+                {
+                  "sourceVolume": "mongo-data",
+                  "containerPath": "/data/db"
+                }
+            ]
         }
     ]
  }


### PR DESCRIPTION
**Story**
As a developer I want to be able to run all auxilary services using docker-compose on my local machine during development.

**Trello Card URL:** 
https://trello.com/c/RTnKQQNx/48-as-a-developer-i-want-to-be-able-to-run-all-auxilary-services-using-docker-compose-on-my-local-machine-during-development

**QA - TeamCity Branch deployment was done to confirm that it works**
https://ci.konfigu.com/viewType.html?buildTypeId=nookrio_ApplicationDeployment&branch_nookrio=%2F48&tab=buildTypeStatusDiv

**Info**
The base Readme.md has some instructions, running `docker-compose up -d` on the local environment in the root of the project will bring up the services.

MongoDB and Redis are deployed as containers to the EC2 instance via ECS. See `./infra/auxiliary` for details. Host mode networking is used which means that in order to access those services from the api container, you have to hit the private ip address of the server. The DNS record `aux.nookr.io` was created to faciliate this.

An example mongoose call was added to the API to illustrate basic db writing. 

Adding my IP address to the operators security group allowed me to connect to the mongodb and redis services from my laptop on the remote server.

![image](https://user-images.githubusercontent.com/23546514/37874629-3897f416-307e-11e8-896f-fc23ab4dd84f.png)
