### PR TITLE
Bugfix/63 - Fix API Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,4 +2,4 @@ FROM node:alpine
 COPY . /srv
 WORKDIR /srv
 RUN npm install --production
-CMD ["node", "app.js"]
+CMD ["node", "./src/app.js"]

--- a/api/package.json
+++ b/api/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "node_modules/.bin/nodemon --watch /src ./src/app.js",
-    "prod": "node app.js",
+    "prod": "node src/app.js",
     "clean": "rm -rf node_modules"
   },
   "author": "",


### PR DESCRIPTION
I thought the Dockerfile was using `npm run prod` but actually it wasn't, it cares where the `app.js` file is.. so I changed it.