### PR TITLE
65 - Update brand & navigation font

### DIFF
--- a/ui/bootstrap/scss/_nav.scss
+++ b/ui/bootstrap/scss/_nav.scss
@@ -11,6 +11,11 @@
   list-style: none;
 }
 
+.nav li{
+  padding-left: 15px;
+  font-weight: 300;
+}
+
 .nav-link {
   display: block;
   padding: $nav-link-padding-y $nav-link-padding-x;

--- a/ui/bootstrap/scss/_nav.scss
+++ b/ui/bootstrap/scss/_nav.scss
@@ -11,10 +11,6 @@
   list-style: none;
 }
 
-.nav li{
-  padding-left: 15px;
-  font-weight: 300;
-}
 
 .nav-link {
   display: block;

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -4,19 +4,19 @@
       <span class="navbar-brand mb-0 h1">nookr.io</span>
       <span class="navbar-text">
         <ul class="nav">
-          <li class="ml-1">
+          <li class="ml-1 pl-2">
             <router-link :to="{ name: 'SearchBooks' }">Search</router-link>
           </li>
-          <li class="ml-1">
+          <li class="ml-1 pl-2">
             <router-link :to="{ name: 'BookList' }">Book List</router-link>
           </li>
-          <li class="ml-1">
+          <li class="ml-1 pl-2">
             <router-link :to="{ name: 'NYBooks' }">NY Bestsellers</router-link>
-          <li>|</li>
-          <li class="ml-1" v-if="!('Login' === $route.name)">
+          <li class="pl-2">|</li>
+          <li class="ml-1 pl-2" v-if="!('Login' === $route.name)">
             <router-link :to="{ name: 'Login' }">Login</router-link>
           </li>
-          <li class="ml-1" v-if="!('Register' === $route.name)">
+          <li class="ml-1 pl-2" v-if="!('Register' === $route.name)">
             <router-link :to="{ name: 'Register' }">Register</router-link>
           </li>
         </ul>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -41,8 +41,5 @@ export default {
   .navbar-brand {
     font-family: Pacifico;
   }
-  .nav li{
-    padding-left: 15px;
-    font-weight: lighter;
-  }
+
 </style>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -40,6 +40,7 @@ export default {
 <style>
   .navbar-brand {
     font-family: Pacifico;
+    font-size: 1.8rem;
   }
 
 </style>


### PR DESCRIPTION
Brand font was too small, increased size.

Navigation font weighting was too light causing the background colour to bleed through. As a result, the font was no longer "white" and failed colour contrast requirements according to WCAG 2.0. Increased font weighting to re-mediate this issue.

Adjusted padding and margin settings for navigation items using bootstrap classes.