### PR TITLE
72 - View best seller list by date & additional filter options.

### DIFF
--- a/ui/bootstrap/scss/_variables.scss
+++ b/ui/bootstrap/scss/_variables.scss
@@ -256,7 +256,7 @@ $h5-font-size:                $font-size-base * 1.25 !default;
 $h6-font-size:                $font-size-base !default;
 
 $headings-margin-bottom:      ($spacer / 2) !default;
-$headings-font-family:        'Helvetica Neue';
+$headings-font-family:        'Open Sans', sans-serif;
 $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
 $headings-color:              inherit !default;

--- a/ui/src/components/BookList/BookShelf.vue
+++ b/ui/src/components/BookList/BookShelf.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="book-shelf">
       <div class="recommendation">
-        <div class="recommendation-title">{{shelfTitle}}</div>
+        <h3>{{shelfTitle}}</h3>
         <hr>
           <span v-for="n in books.length">
           <book-thumbnail class="book-thumbnail" v-bind:book="books[n-1]"></book-thumbnail>

--- a/ui/src/components/NYBooks.vue
+++ b/ui/src/components/NYBooks.vue
@@ -38,7 +38,6 @@
                 :disabled="isLoading"
                 class="mb-2 mr-sm-2 pt-1 col-sm-7"
                 id="filterByWeeks"
-                type="number"
                 v-focus>
       </p>
       <button
@@ -99,6 +98,12 @@
     methods: {
       filterBooks: function () {
         this.isLoading = true
+        if (!this.filterDate && !this.weeksOnList) {
+          this.errors = []
+          this.errors.push('Please enter at least one criteria to filter by')
+          this.isLoading = false
+          return
+        }
         if (this.filterDate && !this.weeksOnList) {
           this.errors = []
           if (!this.validDate(this.filterDate)) {
@@ -123,7 +128,7 @@
         }
         if (this.weeksOnList && !this.filterDate) {
           this.errors = []
-          if (this.weeksOnList < 0) {
+          if (!this.validWeeks(this.weeksOnList) || this.weeksOnList < 0) {
             this.errors.push('Please enter a valid number (weeks on best sellers list must be zero or greater)')
             this.isLoading = false
             return
@@ -149,7 +154,7 @@
             this.errors.push('Please enter a valid date (YYYY-MM-DD)')
             this.isLoading = false
           }
-          if (this.weeksOnList < 0) {
+          if (!this.validWeeks(this.weeksOnList) || this.weeksOnList < 0) {
             this.errors.push('Please enter a valid number (weeks on best sellers list must be zero or greater)')
             this.isLoading = false
           }
@@ -185,6 +190,10 @@
       validDate: function (filterDate) {
         var re = /(?:19|20)[0-9]{2}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1[0-9]|2[0-9])|(?:(?!02)(?:0[1-9]|1[0-2])-(?:30))|(?:(?:0[13578]|1[02])-31))/
         return re.test(filterDate)
+      },
+      validWeeks: function (weeksOnList) {
+        var re = /[0-9]+/
+        return re.test(weeksOnList)
       }
     },
     // https://vuejs.org/v2/guide/custom-directive.html

--- a/ui/src/components/NYBooks.vue
+++ b/ui/src/components/NYBooks.vue
@@ -12,21 +12,32 @@
           v-on:click="toggleFilter()">{{ showHide }} Filter Options
       </button>
       <div class="accordion" v-if="showFilter === true">
-        <label for="filterByDate">Filter by date the best sellers list was
-          published on NYTimes.com</label> 
+      <p>
+        <label for="filterByDate">Best Sellers list at date:</label><br>
         <input @keyup.enter="filterBooks()"
                 v-model="filterDate"
                 placeholder="YYYY-MM-DD"
                 :disabled="isLoading"
-                class="mb-2 mr-sm-2 pt-1"
+                class="mb-2 mr-sm-2 pt-1 col-sm-4"
                 id="filterByDate"
                 v-focus>
-        <button
-            type="button"
-            class="btn btn-primary mb-2 mr-sm-2"
-            :disabled="isLoading"
-            v-on:click="filterBooks()">Filter
-        </button>
+      </p>
+      <p>
+        <label for="filterByWeeks">Weeks on Best Sellers list: </label><br>
+        <input @keyup.enter="filterBooks()"
+                v-model="weeksOnList"
+                placeholder="1"
+                :disabled="isLoading"
+                class="mb-2 mr-sm-2 pt-1 col-sm-4"
+                id="filterByWeeks"
+                v-focus>
+      </p>
+      <button
+          type="button"
+          class="btn btn-primary mb-2 mr-sm-2 col-sm-4"
+          :disabled="isLoading"
+          v-on:click="filterBooks()">Filter
+      </button>
       </div>
     </form>
     </div>
@@ -37,6 +48,7 @@
               <div class="book-title">{{book.book_details[0].title}}</div>
               <div class="book-authors">{{book.book_details[0].author}}</div>
           </div>
+          <div class="book-weeks float-md-right col-sm-3">Weeks on list: {{book.weeks_on_list}}</div>
         </div>
       </div>
     </div>
@@ -53,6 +65,7 @@
         books: [],
         isLoading: false,
         filterDate: '',
+        weeksOnList: '',
         showFilter: false,
         showHide: 'Show'
       }
@@ -76,20 +89,55 @@
     methods: {
       filterBooks: function () {
         this.isLoading = true
-        axios.get('https://api.nytimes.com/svc/books/v3/lists.json', {
-          params: {
-            'api-key': '29ff6820315e44e5b7b9060c0aa39d52',
-            'list': 'combined-print-and-e-book-fiction',
-            'published-date': this.filterDate
-          }
-        })
-          .then((response) => {
-            this.isLoading = false
-            this.books = response.data.results
-          }, (error) => {
-            this.isLoading = false
-            console.log(error)
+        if (this.filterDate) {
+          axios.get('https://api.nytimes.com/svc/books/v3/lists.json', {
+            params: {
+              'api-key': '29ff6820315e44e5b7b9060c0aa39d52',
+              'list': 'combined-print-and-e-book-fiction',
+              'published-date': this.filterDate
+            }
           })
+            .then((response) => {
+              this.isLoading = false
+              this.books = response.data.results
+            }, (error) => {
+              this.isLoading = false
+              console.log(error)
+            })
+        }
+        if (this.weeksOnList) {
+          axios.get('https://api.nytimes.com/svc/books/v3/lists.json', {
+            params: {
+              'api-key': '29ff6820315e44e5b7b9060c0aa39d52',
+              'list': 'combined-print-and-e-book-fiction',
+              'weeks-on-list': this.weeksOnList
+            }
+          })
+            .then((response) => {
+              this.isLoading = false
+              this.books = response.data.results
+            }, (error) => {
+              this.isLoading = false
+              console.log(error)
+            })
+        }
+        if (this.weeksOnList && this.filterDate) {
+          axios.get('https://api.nytimes.com/svc/books/v3/lists.json', {
+            params: {
+              'api-key': '29ff6820315e44e5b7b9060c0aa39d52',
+              'list': 'combined-print-and-e-book-fiction',
+              'weeks-on-list': this.weeksOnList,
+              'published-date': this.filterDate
+            }
+          })
+            .then((response) => {
+              this.isLoading = false
+              this.books = response.data.results
+            }, (error) => {
+              this.isLoading = false
+              console.log(error)
+            })
+        }
       },
       toggleFilter: function () {
         this.showFilter = !this.showFilter
@@ -131,6 +179,10 @@
   .book-authors{
     font-size: larger;
     color: #5f5b5f;
+  }
+  .book-weeks{
+    font-size: smaller;
+    float:right;
   }
   .container{
     margin-top: 40px;

--- a/ui/src/components/NYBooks.vue
+++ b/ui/src/components/NYBooks.vue
@@ -1,29 +1,64 @@
 <template>
-    <main class="container">
-      <div id="book-list container ">
-        <div v-for="book in books">
-          <div class="book center-block row">
-            <div class="book-text col-sm-7 col-md-9">
-                <div class="book-title">{{book.book_details[0].title}}</div>
-                <div class="book-authors">{{book.book_details[0].author}}</div>
-            </div>
+  <div class="container col-md-6">
+    <h2>New York Times Best Sellers
+      <icon v-if="isLoading" class="fa-spin" name="sync"></icon>
+    </h2>
+    <hr>
+    <div class="filter-options">
+      <form class="form" v-on:submit.prevent>
+      <button
+          type="button"
+          class="btn btn-secondary"
+          v-on:click="toggleFilter()">{{ showHide }} Filter Options
+      </button>
+      <div class="accordion" v-if="showFilter === true">
+        <label for="filterByDate">Filter by date the best sellers list was
+          published on NYTimes.com</label> 
+        <input @keyup.enter="filterBooks()"
+                v-model="filterDate"
+                placeholder="YYYY-MM-DD"
+                :disabled="isLoading"
+                class="mb-2 mr-sm-2 pt-1"
+                id="filterByDate"
+                v-focus>
+        <button
+            type="button"
+            class="btn btn-primary mb-2 mr-sm-2"
+            :disabled="isLoading"
+            v-on:click="filterBooks()">Filter
+        </button>
+      </div>
+    </form>
+    </div>
+    <div id="book-list container">
+      <div v-for="book in books">
+        <div class="book center-block row">
+          <div class="book-text col-sm-7 col-md-9">
+              <div class="book-title">{{book.book_details[0].title}}</div>
+              <div class="book-authors">{{book.book_details[0].author}}</div>
           </div>
         </div>
       </div>
-    </main>
+    </div>
+  </div>
 </template>
 
 <script>
   import axios from 'axios'
 
-export default {
+  export default {
     name: 'get-books',
     data () {
       return {
-        books: []
+        books: [],
+        isLoading: false,
+        filterDate: '',
+        showFilter: false,
+        showHide: 'Show'
       }
     },
     created: function () {
+      this.isLoading = true
       axios.get('https://api.nytimes.com/svc/books/v3/lists.json', {
         params: {
           'api-key': '29ff6820315e44e5b7b9060c0aa39d52',
@@ -31,10 +66,48 @@ export default {
         }
       })
         .then((response) => {
+          this.isLoading = false
           this.books = response.data.results
         }, (error) => {
+          this.isLoading = false
           console.log(error)
         })
+    },
+    methods: {
+      filterBooks: function () {
+        this.isLoading = true
+        axios.get('https://api.nytimes.com/svc/books/v3/lists.json', {
+          params: {
+            'api-key': '29ff6820315e44e5b7b9060c0aa39d52',
+            'list': 'combined-print-and-e-book-fiction',
+            'published-date': this.filterDate
+          }
+        })
+          .then((response) => {
+            this.isLoading = false
+            this.books = response.data.results
+          }, (error) => {
+            this.isLoading = false
+            console.log(error)
+          })
+      },
+      toggleFilter: function () {
+        this.showFilter = !this.showFilter
+        if (this.showFilter === true) {
+          this.showHide = 'Hide'
+        } else {
+          this.showHide = 'Show'
+        }
+      }
+    },
+    // https://vuejs.org/v2/guide/custom-directive.html
+    directives: {
+      focus: {
+        // directive definition
+        inserted: function (el) {
+          el.focus()
+        }
+      }
     }
   }
 </script>
@@ -58,5 +131,11 @@ export default {
   .book-authors{
     font-size: larger;
     color: #5f5b5f;
+  }
+  .container{
+    margin-top: 40px;
+  }
+  .filter-options button{
+    margin-bottom: 15px;
   }
 </style>


### PR DESCRIPTION
## Feature #72
### Story
As a site visitor, I want to be able to see a list of best seller books. Such as the current month, the current year, and previous years. I would also like to be able to control the contents of the list, by choosing the criteria to filter by.

### Delivered
- A user can control the contents of the list by choosing criteria to filter:
  - By specified dates.
  - By number of weeks a title has been on the best sellers list.
- Filter criteria is validated and appropriate errors are displayed.
- Number of weeks a title has been on the best sellers list now displayed.

### Not Delivered
- A user can see a list of best sellers for particular months / years.
  - _Current API does not accommodate this functionality, as the lists provided are weekly. Information for overall best sellers over the course of a month or year cannot be gathered._

### Minor Changes
- Updated font variables for headings to match the rest of the application.
- Updated Bookshelf.vue "heading" from a `<div>` styled to visually appear like a heading to semantic `<h2>` for better compatibility with Adaptive Technology.