### PR TITLE
Cache book results from the NYT best sellers to the database

### DIFF
--- a/api/src/models/nyBook.js
+++ b/api/src/models/nyBook.js
@@ -1,0 +1,10 @@
+var mongoose = require('mongoose');
+
+var nyBookSchema = mongoose.Schema( {
+    title       : String,
+    author      : String,
+    listDate    : String,
+    ISBN        : String
+  });
+
+  module.exports = mongoose.model('NYBooks', nyBookSchema);


### PR DESCRIPTION
Completed feature 62. 

Currently, I've implemented it so that the server pulls weekly lists from NY Times back to 2013/01/01 and stores the all books found in the database with Title, Author, List Date, ISBN13 values (others can easily be added). This should make it possible to query the database for bestsellers from a month/year?
setInterval function is used to make requests approx. every 300 milliseconds which seems to avoid call limit issues. 
Currently implemented as a route in route.js so that visiting /populateNY on the server will cause it to pull and populate the database. (The function wipes the book collection first (so duplicates aren't created) and I assume calls the NY api a lot so I recommend not doing this too much unless you don't mind not being able to pull books for a day or so). 
I wasn't sure about putting the function here but wasn't sure where else to put it or how to have the server run it. If there's a better way I'm hoping it won't be much more difficult than copy pasting this code elsewhere. 